### PR TITLE
Add a dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="de"><head>
 <meta charset="utf-8" />
+<!-- we can do both, but favour light -->
+<meta name="color-scheme" content="light dark">
 <style>
 html {
     font-size: 16px;
@@ -48,6 +50,19 @@ a:hover {
   51% {color: #099;}
   68% {color: #00f;}
   85% {color: #909;}
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #333;
+        color: #ccc;
+    }
+    
+    img {
+        -webkit-filter: invert(0.8);
+        -ms-filter: "progid:DXImageTransform.Microsoft.Invert(0.8)";
+        filter: invert(0.8);
+    }
 }
 </style>
 <title>chaos.jetzt - Junges Chaos Bildet Banden</title>


### PR DESCRIPTION
This is being used if the users' system is set to a dark theme.

The way this works: It uses `prefers-color-scheme` to determine the system theme.

| before | after |
|--------|---------|
|  ![grafik](https://user-images.githubusercontent.com/5578100/78459773-b5d7c480-76bb-11ea-8794-3eaad6945c2f.png) | ![grafik](https://user-images.githubusercontent.com/5578100/78459818-15ce6b00-76bc-11ea-800c-d0500e590682.png) |

I'm not quite sure whether the contrast is enough - and I didn't test it in any version of Internet Explorer.
